### PR TITLE
Set the default value of Priority Id because Priority Id is required field in API V2 but many users may want to omit it

### DIFF
--- a/backlog-template-issue-gas.js
+++ b/backlog-template-issue-gas.js
@@ -41,6 +41,9 @@ var CONVERT_NAME = {
 	"親課題" : "parentIssueId"
 };
 
+/** 優先度IDのデフォルト値 */
+var DEFAULT_PRIORITYID = "3";
+
 // ------------------------- グローバルオブジェクト -------------------------
 
 /** 入力パラメータ */
@@ -103,7 +106,10 @@ function getUsersV2(projectId) {
  */
 
 function createIssueV2(issue) {
-	
+	if (issue["prorityId"] == undefined) {
+		issue["priorityId"] = DEFAULT_PRIORITYID;
+	}
+
 	var query = "?apiKey=" + PropertiesService.getUserProperties().getProperty("bti.apikey") + "&" + build_query(issue);
 
 	var uri = getRequestUri_V2() + "issues";


### PR DESCRIPTION
度々すみません。XML-RPC時代は課題登録時に必須でなかった優先度IDが、API V2だと必須になっていたようです。。すみませんが、こちら修正しましたのでマージお願いします。

（あと、お手数なのですがオリジナルのスプレッドシートの方に、件名（必須）、種別（必須）と入れて頂けると助かります。。）

コミットメッセージ：
Set the default value of Priority Id because Priority Id is required field in API V2 but many users may want to omit it